### PR TITLE
Update to Realm 2.3.0

### DIFF
--- a/TrySwiftData.podspec
+++ b/TrySwiftData.podspec
@@ -132,6 +132,6 @@ s.homepage     = "https://tryswift.co"
   # s.requires_arc = true
 
   # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
-  s.dependency 'RealmSwift', '~> 2.1.1'
+  s.dependency 'RealmSwift', '~> 2.3.0'
 
 end

--- a/TrySwiftData/Sources/Speaker.swift
+++ b/TrySwiftData/Sources/Speaker.swift
@@ -31,7 +31,7 @@ public class Speaker: Object {
     
     public class var speakers: Results<Speaker> {
         let realm = try! Realm()
-        return realm.objects(Speaker.self).filter("hidden == false").sorted(byProperty: "name")
+        return realm.objects(Speaker.self).filter("hidden == false").sorted(byKeyPath: "name")
     }
     
     #if os(iOS)


### PR DESCRIPTION
Updates the version of Realm used by this framework to 2.3.0. The version number has been updated in the podspec, and a deprecated API has been fixed.